### PR TITLE
fix(startup): execute "ifreload -a" after the interfaces came up

### DIFF
--- a/configs/scripts/thunderbolt-startup.sh
+++ b/configs/scripts/thunderbolt-startup.sh
@@ -28,4 +28,13 @@ if ip link show en06 &> /dev/null; then
     echo "$(date): en06 configured" >> "$LOGFILE"
 fi
 
+# Reload interface configuration
+echo "$(date): Reloading interface configuration" >> "$LOGFILE"
+if ifreload -a &> /dev/null; then
+		echo "$(date): Interface configuration reloaded successfully" >> "$LOGFILE"
+else
+		echo "$(date): Failed to reload interface configuration" >> "$LOGFILE"
+		exit 1
+fi
+
 echo "$(date): Thunderbolt configuration completed" >> "$LOGFILE"

--- a/docs/04-network-config.md
+++ b/docs/04-network-config.md
@@ -222,6 +222,15 @@ if ip link show en06 &>/dev/null; then
     echo "$(date): en06 configured" >> "$LOGFILE"
 fi
 
+# Reload interface configuration
+echo "$(date): Reloading interface configuration" >> "$LOGFILE"
+if ifreload -a &> /dev/null; then
+    echo "$(date): Interface configuration reloaded successfully" >> "$LOGFILE"
+else
+    echo "$(date): Failed to reload interface configuration" >> "$LOGFILE"
+    exit 1
+fi
+
 echo "$(date): Thunderbolt configuration completed" >> "$LOGFILE"
 EOF'
     ssh $node "chmod +x /usr/local/bin/thunderbolt-startup.sh"

--- a/scripts/04-setup-udev-rules.sh
+++ b/scripts/04-setup-udev-rules.sh
@@ -140,6 +140,15 @@ if ip link show en06 &>/dev/null; then
     echo "$(date): en06 configured" >> "$LOGFILE"
 fi
 
+# Reload interface configuration
+echo "$(date): Reloading interface configuration" >> "$LOGFILE"
+if ifreload -a &> /dev/null; then
+		echo "$(date): Interface configuration reloaded successfully" >> "$LOGFILE"
+else
+		echo "$(date): Failed to reload interface configuration" >> "$LOGFILE"
+		exit 1
+fi
+
 echo "$(date): Thunderbolt configuration completed" >> "$LOGFILE"
 EOF'
         ssh "root@$node" "chmod +x /usr/local/bin/thunderbolt-startup.sh"


### PR DESCRIPTION
## Summary

After a node reboot, the IPs on the en05 and en06 interfaces where missing. Running `ifreload -a` fixes this. Therefore this was added to the thunderbolt-startup script.

## Type of Change

<!-- Mark with an `x` - this helps with release notes -->

- [ ] `feat:` New feature or enhancement
- [x] `fix:` Bug fix
- [ ] `docs:` Documentation only
- [ ] `refactor:` Code refactoring (no functional change)
- [ ] `ci:` CI/CD or workflow changes
- [ ] `chore:` Maintenance or dependency updates

## Testing

<!-- How did you test these changes? -->

- [x] Tested on Proxmox VE 9.x
- [x] Scripts are idempotent (safe to run multiple times)
- [x] Documentation matches actual behavior

## Hardware Tested (if applicable)

<!-- If you tested on specific hardware, please share -->

- Hardware: Asus NUC 14 Pro
- TB4 Controller: Intel Corporation Meteor Lake-P Thunderbolt 4 PCI Express
- Proxmox Version: 9.2.5

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Changes have been self-reviewed
- [x] No secrets or credentials included
- [x] Scripts include appropriate comments

## Additional Context

<!-- Optional: screenshots, benchmark results, or notes for reviewers -->
